### PR TITLE
fix same name file-loader in webpack for netlify

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -36,7 +36,7 @@ module.exports = {
           {
             loader: 'file-loader',
             options: {
-              name: '[name].[hash].[ext]',
+              name: '[name]_[hash].[ext]',
             },
           },
         ],


### PR DESCRIPTION
same name file-loader example
`
ERROR in Conflict: Multiple assets emit different content to the same filename hero-image_1-large.785b40e102a01691b70a77ab08f12926.webp

ERROR in Conflict: Multiple assets emit different content to the same filename hero-image_1-small.70e35150e21ba801822f465d3cdd27e5.webp

ERROR in Conflict: Multiple assets emit different content to the same filename hero-image_1.9fd2ac6150beaffe6ba9d6154e8f5c84.webp
` 
when deploy to netlify